### PR TITLE
removing sync line from connections

### DIFF
--- a/packages/engine-frontend/components/ConnectionPortal.tsx
+++ b/packages/engine-frontend/components/ConnectionPortal.tsx
@@ -115,7 +115,9 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
                                   {category.name}
                                 </Badge>
                               </div>
-                              {conn.syncInProgress ? (
+                              {conn.pipelineIds.length === 0 ? (
+                                <div className="h-6" /> // Add empty space for vertical centering
+                              ) : conn.syncInProgress ? (
                                 <div className="flex flex-row items-center justify-start gap-2">
                                   <Loader className="size-5 animate-spin text-[#8A5DF6]" />
                                   <p className="font-semibold">Syncing...</p>

--- a/packages/engine-frontend/components/ConnectionPortal.tsx
+++ b/packages/engine-frontend/components/ConnectionPortal.tsx
@@ -105,8 +105,8 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
                               connector={conn.connectorConfig.connector}
                               className="size-[64px] rounded-lg"
                             />
-                            <div className="flex flex-col gap-2">
-                              <div className="flex flex-row gap-2">
+                            <div className="flex flex-col h-full justify-center">
+                              <div className="flex flex-row gap-2 items-center">
                                 <h4 className="font-bold">
                                   {conn.connectorName.charAt(0).toUpperCase() +
                                     conn.connectorName.slice(1)}
@@ -115,15 +115,17 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
                                   {category.name}
                                 </Badge>
                               </div>
-                              {conn.pipelineIds.length === 0 ? (
-                                <div className="h-6" /> // Add empty space for vertical centering
-                              ) : conn.syncInProgress ? (
-                                <div className="flex flex-row items-center justify-start gap-2">
-                                  <Loader className="size-5 animate-spin text-[#8A5DF6]" />
-                                  <p className="font-semibold">Syncing...</p>
+                              {conn.pipelineIds.length > 0 && (
+                                <div className="mt-2">
+                                  {conn.syncInProgress ? (
+                                    <div className="flex flex-row items-center justify-start gap-2">
+                                      <Loader className="size-5 animate-spin text-[#8A5DF6]" />
+                                      <p className="font-semibold">Syncing...</p>
+                                    </div>
+                                  ) : (
+                                    <p>Successfully synced</p>
+                                  )}
                                 </div>
-                              ) : (
-                                <p>Successfully synced</p>
                               )}
                             </div>
                           </div>


### PR DESCRIPTION
Google for example has no pipelines / syncing and it currently shows 
![image](https://github.com/user-attachments/assets/73bd7783-4b2b-4556-8470-d561c14ad1fe)

This PR makes it so that it shows this instead
<img width="480" alt="image" src="https://github.com/user-attachments/assets/5a3e1262-44de-4cba-81e0-6ee5077af51c">
And this for cases with pipelines (regression test)
<img width="406" alt="image" src="https://github.com/user-attachments/assets/33823887-ee30-48ab-bc6a-7eb7a190eb78">
