### PR TITLE
WIP Access Token Refresh in getResource and listResource

### DIFF
--- a/kits/cdk/internal/api-key-encoding.ts
+++ b/kits/cdk/internal/api-key-encoding.ts
@@ -1,12 +1,15 @@
 import {TRPCError} from '@trpc/server'
 
 export function decodeApikey(apikey: string) {
+  const message = 'Invalid ' + apikey?.includes('Bearer') ? 'Authorization Bearer Token' : 'API Key' + ' provided'
+
   try {
     const [id, key, ...rest] = atob(apikey).split(':')
+
     if (!id || !key || rest.length > 0) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
-        message: 'Invalid API Key format',
+        message
       })
     }
     return [id, key] as const
@@ -14,9 +17,10 @@ export function decodeApikey(apikey: string) {
     if (`${err}`.includes('InvalidCharacterError')) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
-        message: 'Invalid API Key format',
+        message
       })
     }
+    console.error('[decodeApikey] error', err)
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
       message: `${err}`,

--- a/kits/cdk/internal/oauthConnector.ts
+++ b/kits/cdk/internal/oauthConnector.ts
@@ -121,7 +121,12 @@ export function makeOauthConnectorServer({
         .GET('/connection/{connectionId}', {
           params: {
             path: {connectionId: resoId},
-            query: {provider_config_key: ccfgId, refresh_token: true},
+            query: {
+              provider_config_key: ccfgId,
+              refresh_token: true,
+              // thought this would make forceRefresh work but wasn't called in the getResource code path
+              // force_refresh: true,
+            },
           },
         })
         .then((r) => r.data)

--- a/kits/cdk/internal/remote-procedure.ts
+++ b/kits/cdk/internal/remote-procedure.ts
@@ -35,6 +35,11 @@ export async function getRemoteContext(ctx: ProtectedContext) {
   const nango = initNangoSDK({
     headers: {authorization: `Bearer ${ctx.env.NANGO_SECRET_KEY}`},
   })
+  
+  // @ts-expect-error oauth is conditionally present
+  const oauthCredentialsExpiryTime = new Date(resource.settings?.oauth?.credentials?.raw?.expires_at ?? new Date(new Date().getTime() + 1000));
+  const forceRefreshCredentials = oauthCredentialsExpiryTime < new Date();
+  
   const settings = {
     ...resource.settings,
     ...(resource.connectorConfig.connector.metadata?.nangoProvider && {
@@ -44,7 +49,7 @@ export async function getRemoteContext(ctx: ProtectedContext) {
             path: {connectionId},
             query: {
               provider_config_key: providerConfigKey,
-              force_refresh: true, // TODO: Conditionally call me, this is what makes it work
+              force_refresh: forceRefreshCredentials, // Conditionally call based on expiry
             },
           },
         })

--- a/kits/cdk/internal/remote-procedure.ts
+++ b/kits/cdk/internal/remote-procedure.ts
@@ -42,7 +42,10 @@ export async function getRemoteContext(ctx: ProtectedContext) {
         .GET('/connection/{connectionId}', {
           params: {
             path: {connectionId},
-            query: {provider_config_key: providerConfigKey},
+            query: {
+              provider_config_key: providerConfigKey,
+              force_refresh: true, // TODO: Conditionally call me, this is what makes it work
+            },
           },
         })
         .then((r) => nangoConnectionWithCredentials.parse(r.data)),

--- a/packages/engine-backend/router/resourceRouter.ts
+++ b/packages/engine-backend/router/resourceRouter.ts
@@ -249,7 +249,7 @@ export const resourceRouter = trpc.router({
       
       console.log('[listResources] Refreshing tokens for all resources');
       const updatedResources = await Promise.all(resources.map(async (reso) => {
-        // @ts-ignore
+        // @ts-expect-error
         const expiresAt = reso?.settings?.['oauth']?.credentials?.raw?.expires_at
 
         if (expiresAt && (input.forceRefresh || new Date(expiresAt).getTime() <= Date.now())) {
@@ -269,7 +269,7 @@ export const resourceRouter = trpc.router({
       if (!input.refreshToken) {
         console.log('[listResources] Removing refresh_token from the response');
         resources = resources.map(reso => {
-          // @ts-ignore
+          // @ts-expect-error
           if (reso?.settings?.['oauth']?.credentials?.raw?.refresh_token) {
             return {
               ...reso,
@@ -278,12 +278,12 @@ export const resourceRouter = trpc.router({
                 oauth: {
                   ...reso.settings['oauth'],
                   credentials: {
-                    // @ts-ignore
+                    // @ts-expect-error
                     ...reso.settings['oauth']?.credentials,
                     raw: {
-                      // @ts-ignore
+                      // @ts-expect-error
                       ...reso.settings['oauth']?.credentials?.raw,
-                      // @ts-ignore
+                      // @ts-expect-error
                       refresh_token: undefined
                     }
                   }
@@ -325,12 +325,12 @@ export const resourceRouter = trpc.router({
       )
 
       // Handle forceRefresh and refreshToken
-      // @ts-ignore
+      // @ts-expect-error
       const expiresAt = reso?.settings?.['oauth']?.credentials?.raw?.expires_at
       
       if (expiresAt && (input.forceRefresh ||new Date(expiresAt).getTime() <= Date.now())) {
         console.log('[getResource] Refreshing token');
-        let resoCheck = await performResourceCheck(ctx, reso.id, {});
+        const resoCheck = await performResourceCheck(ctx, reso.id, {});
         if(!resoCheck) {
           console.warn(`[getResource] resourceCheck not implemented for ${reso.connectorName} which requires a refresh. Returning the stale resource.`);
         }
@@ -339,9 +339,9 @@ export const resourceRouter = trpc.router({
       
       if(!input.refreshToken) {
         // Remove refresh_token from the response for security reasons
-        // @ts-ignore
+        // @ts-expect-error
         if (reso?.settings?.['oauth']?.credentials?.raw?.refresh_token) {
-          // @ts-ignore
+          // @ts-expect-error
           delete reso.settings['oauth'].credentials.raw.refresh_token;
         }
       }

--- a/packages/engine-backend/router/resourceRouter.ts
+++ b/packages/engine-backend/router/resourceRouter.ts
@@ -22,6 +22,52 @@ export {type inferProcedureInput} from '@openint/trpc'
 
 const tags = ['Core']
 
+async function performResourceCheck(
+  ctx: any,
+  resoId: string,
+  opts: any,
+) {
+  const remoteCtx = await getRemoteContext({
+    ...ctx,
+    remoteResourceId: resoId,
+  })
+  const {connectorConfig: int, ...reso} =
+    await ctx.asOrgIfNeeded.getResourceExpandedOrFail(resoId)
+
+  const resoUpdate = await int.connector.checkResource?.({
+    settings: remoteCtx.remote.settings,
+    config: int.config,
+    options: opts ?? {},
+    instance: remoteCtx.remote.instance,
+    context: {
+      webhookBaseUrl: joinPath(
+        ctx.apiUrl,
+        parseWebhookRequest.pathOf(int.id),
+      ),
+    },
+  })
+  if (resoUpdate || opts?.import !== false) {
+    /** Do not update the `endUserId` here... */
+    await ctx.asOrgIfNeeded._syncResourceUpdate(int, {
+      ...(opts?.import && {
+        endUserId: reso.endUserId ?? undefined,
+      }),
+      ...resoUpdate,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      settings: {
+        ...(opts?.import && remoteCtx.remote.settings),
+        ...resoUpdate?.settings,
+      },
+      resourceExternalId:
+        resoUpdate?.resourceExternalId ?? extractId(reso.id)[2],
+    })
+  }
+  if (!int.connector.checkResource) {
+    return resoUpdate;
+  }
+  return resoUpdate
+}
+
 export const resourceRouter = trpc.router({
   // TODO: maybe we should allow resourceId to be part of the path rather than only in the headers
 
@@ -189,13 +235,66 @@ export const resourceRouter = trpc.router({
           endUserId: zEndUserId.nullish(),
           connectorConfigId: zId('ccfg').nullish(),
           connectorName: z.string().nullish(),
+          refreshToken: z.boolean().optional(),
+          forceRefresh: z.boolean().optional(),
         })
         .optional(),
     )
     .output(z.array(zRaw.resource))
     .query(async ({input = {}, ctx}) => {
-      const resources =
+      let resources =
         await ctx.services.metaService.tables.resource.list(input)
+
+      // Handle forceRefresh for each resource
+      
+      console.log('[listResources] Refreshing tokens for all resources');
+      const updatedResources = await Promise.all(resources.map(async (reso) => {
+        // @ts-ignore
+        const expiresAt = reso?.settings?.['oauth']?.credentials?.raw?.expires_at
+
+        if (expiresAt && (input.forceRefresh || new Date(expiresAt).getTime() <= Date.now())) {
+          console.log(`[listResources] Refreshing token for resource ${reso.connectorName}`);
+          const resoCheck = await performResourceCheck(ctx, reso.id, {});
+          if(!resoCheck) {
+            console.warn(`[listResources] resourceCheck not implemented for ${reso.connectorName} which requires a refresh. Returning the stale resource.`);
+          }
+          return resoCheck || reso;
+        }
+        return reso;
+      }));
+
+      resources = updatedResources;
+      
+      // Remove refresh_token from the response for security reasons if not explicitly requested
+      if (!input.refreshToken) {
+        console.log('[listResources] Removing refresh_token from the response');
+        resources = resources.map(reso => {
+          // @ts-ignore
+          if (reso?.settings?.['oauth']?.credentials?.raw?.refresh_token) {
+            return {
+              ...reso,
+              settings: {
+                ...reso.settings,
+                oauth: {
+                  ...reso.settings['oauth'],
+                  credentials: {
+                    // @ts-ignore
+                    ...reso.settings['oauth']?.credentials,
+                    raw: {
+                      // @ts-ignore
+                      ...reso.settings['oauth']?.credentials?.raw,
+                      // @ts-ignore
+                      refresh_token: undefined
+                    }
+                  }
+                }
+              }
+            };
+          }
+          return reso;
+        });
+      }
+
       return resources as Array<ZRaw['resource']>
     }),
   getResource: protectedProcedure
@@ -203,7 +302,11 @@ export const resourceRouter = trpc.router({
       description: 'Not automatically called, used for debugging for now',
       openapi: {method: 'GET', path: '/core/resource/{id}', tags},
     })
-    .input(z.object({id: zId('reso')}))
+    .input(z.object({
+      id: zId('reso'),
+      forceRefresh: z.boolean().optional(),
+      refreshToken: z.boolean().optional()
+    }))
     .output(
       // TODO: Should we expand this?
       zRaw.resource.extend({
@@ -216,10 +319,33 @@ export const resourceRouter = trpc.router({
     )
     .query(async ({input, ctx}) => {
       // do not expand for now otherwise permission issues..
-      const reso = await ctx.services.getResourceOrFail(input.id)
+      let reso = await ctx.services.getResourceOrFail(input.id)
       const ccfg = await ctx.services.getConnectorConfigOrFail(
-        reso.connectorConfigId,
+        reso.connectorConfigId
       )
+
+      // Handle forceRefresh and refreshToken
+      // @ts-ignore
+      const expiresAt = reso?.settings?.['oauth']?.credentials?.raw?.expires_at
+      
+      if (expiresAt && (input.forceRefresh ||new Date(expiresAt).getTime() <= Date.now())) {
+        console.log('[getResource] Refreshing token');
+        let resoCheck = await performResourceCheck(ctx, reso.id, {});
+        if(!resoCheck) {
+          console.warn(`[getResource] resourceCheck not implemented for ${reso.connectorName} which requires a refresh. Returning the stale resource.`);
+        }
+        reso = resoCheck || reso;
+      }
+      
+      if(!input.refreshToken) {
+        // Remove refresh_token from the response for security reasons
+        // @ts-ignore
+        if (reso?.settings?.['oauth']?.credentials?.raw?.refresh_token) {
+          // @ts-ignore
+          delete reso.settings['oauth'].credentials.raw.refresh_token;
+        }
+      }
+
       return {
         ...reso,
         connector_config: R.pick(ccfg, ['id', 'orgId', 'connectorName']),
@@ -236,46 +362,11 @@ export const resourceRouter = trpc.router({
       if (ctx.viewer.role === 'end_user') {
         await ctx.services.getResourceOrFail(resoId)
       }
-      const remoteCtx = await getRemoteContext({
-        ...ctx,
-        remoteResourceId: resoId,
-      })
-      const {connectorConfig: int, ...reso} =
-        await ctx.asOrgIfNeeded.getResourceExpandedOrFail(resoId)
-
-      // console.log('checkResource', {settings, connectorConfig, ...conn}, opts)
-      const resoUpdate = await int.connector.checkResource?.({
-        settings: remoteCtx.remote.settings,
-        config: int.config,
-        options: opts ?? {},
-        instance: remoteCtx.remote.instance,
-        context: {
-          webhookBaseUrl: joinPath(
-            ctx.apiUrl,
-            parseWebhookRequest.pathOf(int.id),
-          ),
-        },
-      })
-      if (resoUpdate || opts?.import !== false) {
-        /** Do not update the `endUserId` here... */
-        await ctx.asOrgIfNeeded._syncResourceUpdate(int, {
-          ...(opts?.import && {
-            endUserId: reso.endUserId ?? undefined,
-          }),
-          ...resoUpdate,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          settings: {
-            ...(opts?.import && remoteCtx.remote.settings),
-            ...resoUpdate?.settings,
-          },
-          resourceExternalId:
-            resoUpdate?.resourceExternalId ?? extractId(reso.id)[2],
-        })
+      const resourceCheck = await performResourceCheck(ctx, resoId, opts);
+      if(!resourceCheck) {
+        return `Resource check not implemented for ${resoId}`;
       }
-      if (!int.connector.checkResource) {
-        return `Not implemented in ${int.connector.name}`
-      }
-      return resoUpdate
+      return resourceCheck;
     }),
 
   // MARK: - Sync
@@ -296,7 +387,6 @@ export const resourceRouter = trpc.router({
         return
       }
       const reso = await ctx.asOrgIfNeeded.getResourceExpandedOrFail(resoId)
-      console.log('[syncResource]', reso, opts)
       // No need to checkResource here as sourceSync should take care of it
 
       if (opts?.metaOnly) {

--- a/packages/engine-backend/router/resourceRouter.ts
+++ b/packages/engine-backend/router/resourceRouter.ts
@@ -283,7 +283,6 @@ export const resourceRouter = trpc.router({
                     raw: {
                       // @ts-expect-error
                       ...reso.settings['oauth']?.credentials?.raw,
-                      // @ts-expect-error
                       refresh_token: undefined
                     }
                   }


### PR DESCRIPTION
This implements two optional query parameters

      forceRefresh: z.boolean().optional(),
      refreshToken: z.boolean().optional()

The code is performing the `performResourceCheck` correctly but it doesn't seem like underlying resources like google or qbo which we need to implement this for support this. Perhaps the `performResourceCheck` logic is wrong? 
