### PR TITLE
Ag iframe message

### DIFF
--- a/packages/engine-frontend/components/AGConnectionPortal.tsx
+++ b/packages/engine-frontend/components/AGConnectionPortal.tsx
@@ -112,6 +112,9 @@ const NewConnectionCard = ({
     <ConnectButton
       // className="bg-purple-400 hover:bg-purple-500"
       className="rounded-md bg-[#8192FF] px-4 py-2 text-white hover:bg-purple-500"
-      connectorConfigFilters={{verticalKey: category.key}}></ConnectButton>
+      connectorConfigFilters={{verticalKey: category.key}}
+      listenForOpen>
+      Connect
+    </ConnectButton>
   </Card>
 )

--- a/packages/engine-frontend/components/ConnectButton.tsx
+++ b/packages/engine-frontend/components/ConnectButton.tsx
@@ -94,6 +94,8 @@ export function MultipleConnectButton({
         window.removeEventListener('message', handleMessage);
       };
     }
+    // to satisfy the linter
+    return () => {};
   }, [listenForOpen]);
   // Unconditional render to avoid delay when dialog is opened
   const content = (


### PR DESCRIPTION
This implements the `triggerConnectDialog` message so that the dialog can be opened externally. 

It could be done in this way. 
```
const iframe = document.getElementById('openint-connect-iframeId');
iframe?.contentWindow.postMessage({type: 'triggerConnectDialog', value: true },'*');
```

We want to be thoughtful about: 
- Is the right API that we want for future?
- Should we hide active connections from this view give that for AG they'll be in the previous AG only AgConnectionPortal screen?
- How do we make it easy to get the developer to get the iframe id? not a problem if they have a single Iframe but what if they have multiple ones? P