### PR TITLE
Add ability to override color configuration for tailwind

### DIFF
--- a/apps/web/app/connect/OrgThemeWrapper.tsx
+++ b/apps/web/app/connect/OrgThemeWrapper.tsx
@@ -8,8 +8,8 @@ export function OrgThemeWrapper({children}: {children: React.ReactNode}) {
     // '--body-background': 'transparent',
     // Temp workaround for not having a --body-background variable just yet...
     // '--inner-background': '0 0% 100%',
-    '--foreground': '192 5.32% 31.57%',
-    '--card-foreground': '192 5.32% 31.57%',
+    // '--foreground': '192 5.32% 31.57%',
+    // '--card-foreground': '192 5.32% 31.57%',
   }
 
   return (

--- a/apps/web/app/connect/portal/page.tsx
+++ b/apps/web/app/connect/portal/page.tsx
@@ -6,6 +6,7 @@ import {getViewerId} from '@openint/cdk'
 import {zConnectPageParams} from '@openint/engine-backend/router/endUserRouter'
 import {AGConnectionPortal, ConnectionPortal} from '@openint/engine-frontend'
 import {ClientRoot} from '@/components/ClientRoot'
+import {ColorConfig} from '@/components/ColorConfig'
 import {SuperHydrate} from '@/components/SuperHydrate'
 import {createServerComponentHelpers} from '@/lib-server/server-component-helpers'
 
@@ -60,6 +61,7 @@ export default async function PortalPage({
   return (
     <ClientRoot accessToken={viewer.accessToken} authStatus="success">
       <SuperHydrate dehydratedState={getDehydratedState()}>
+        <ColorConfig />
         {shouldRenderAG ? <AGConnectionPortal /> : <ConnectionPortal />}
       </SuperHydrate>
     </ClientRoot>

--- a/apps/web/components/ColorConfig.tsx
+++ b/apps/web/components/ColorConfig.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import {useState} from 'react'
+
+interface ThemeColors {
+  background: string
+  border: string
+  foreground: string
+  primary: string
+  primaryForeground: string
+  secondary: string
+  secondaryForeground: string
+  card: string
+  cardForeground: string
+}
+
+const defaultThemeColors: ThemeColors = {
+  background: '0 0% 100%',
+  border: '214.3 31.8% 91.4%',
+  card: '0 0% 100%',
+  cardForeground: '192 5.32% 31.57%',
+  foreground: '192 5.32% 31.57%',
+  primary: '222.2 47.4% 11.2%',
+  primaryForeground: '210 40% 98%',
+  secondary: '210 40% 96.1%',
+  secondaryForeground: '222.2 47.4% 11.2%',
+}
+
+export function ColorConfig() {
+  const [themeColors] = useState<Partial<ThemeColors>>(defaultThemeColors)
+  // TODO: Fetch color config by client if required and update themeColors state.
+
+  return (
+    <style id="theme-colors" jsx global>{`
+      :root {
+        --color-primary: ${themeColors.primary};
+        --color-secondary: ${themeColors.secondary};
+        --color-background: ${themeColors.background};
+        --color-foreground: ${themeColors.foreground};
+        --color-border: ${themeColors.border};
+        --color-input: ${themeColors.foreground};
+        --color-ring: ${themeColors.secondary};
+        --color-primary-foreground: ${themeColors.primaryForeground};
+        --color-secondary-foreground: ${themeColors.secondaryForeground};
+        --card: ${themeColors.card};
+        --card-foreground: ${themeColors.cardForeground};
+      }
+    `}</style>
+  )
+}


### PR DESCRIPTION
- For now we need to provide hsl color variables, probably we can change in the future.
- Added some really basic colors we can override and tested that it works and uses the state values instead of the global.css