### PR TITLE
adding support for qbo bank account and payment receipt APIs

### DIFF
--- a/connectors/connector-qbo/server.ts
+++ b/connectors/connector-qbo/server.ts
@@ -1,4 +1,4 @@
-import {initSDK, modifyRequest, modifyUrl} from '@opensdks/runtime'
+import {initSDK, modifyRequest} from '@opensdks/runtime'
 import type {QBOSDKTypes} from '@opensdks/sdk-qbo'
 import {qboSdkDef} from '@opensdks/sdk-qbo'
 import type {ConnectorServer} from '@openint/cdk'

--- a/unified/unified-accounting/adapters/qbo-adapter.ts
+++ b/unified/unified-accounting/adapters/qbo-adapter.ts
@@ -252,15 +252,9 @@ export const qboAdapter = {
     return mappers.customerIncome(res)
   },
   // @ts-expect-error we can tighten up the types here after opensdks support qbo v4
-  getBankAccounts: async ({instance, input}) => {
+  getBankAccounts: async ({instance, input, env}) => {
     // https://developer.intuit.com/app/developer/qbpayments/docs/api/resources/all-entities/bankaccounts#get-a-list-of-bank-accounts
-    const baseUrl = instance.clientOptions?.baseUrl?.replace(/intuit\.com.*/, "/quickbooks/v4/customers/{customer}/bank-accounts");
-    const res = await instance.request('GET', baseUrl ?? '', {
-      params: {
-        query: {
-          customer: input.customer
-        }
-      },
+    const res = await instance.request('GET', `/bank-accounts/${input.customer}`, {
       headers: {
         'Accept': 'application/json',
         "request-Id": makeUlid()
@@ -271,13 +265,7 @@ export const qboAdapter = {
   // @ts-expect-error we can tighten up the types here after opensdks support qbo v4
   getPaymentReceipt: async ({instance, input}) => {
      // https://developer.intuit.com/app/developer/qbpayments/docs/api/resources/all-entities/paymentreceipt
-     const baseUrl = instance.clientOptions?.baseUrl?.replace(/intuit\.com.*/, `/quickbooks/v4/payments/receipt/{customer_transaction_id}`);
-      const res = await instance.request('GET', baseUrl ?? '', {
-        params: {
-          query: {
-            customer_transaction_id: input.customer_transaction_id
-          }
-        },
+      const res = await instance.request('GET', `/payment-receipts/${input.customer_transaction_id}`, {
         headers: {
           'Accept': 'application/pdf, application/json',
           "request-Id": makeUlid()

--- a/unified/unified-accounting/router.ts
+++ b/unified/unified-accounting/router.ts
@@ -85,6 +85,16 @@ export const accountingRouter = trpc.router({
     }))
     .output(unified.customerIncome)
     .query(async ({input, ctx}) => proxyCallAdapter({input, ctx})),
+  getBankAccounts: procedure
+    .meta(oapi({method: 'GET', path: '/bank-accounts'}))
+    .input(z.object({customer: z.string()}))
+    .output(z.array(unified.usBankAccount))
+    .query(async ({input, ctx}) => proxyCallAdapter({input, ctx})),
+  getPaymentReceipts: procedure
+    .meta(oapi({method: 'GET', path: '/payment-receipt'}))
+    .input(z.object({customer_transaction_id: z.string()}))
+    .output(z.instanceof(Buffer))
+    .query(async ({input, ctx}) => proxyCallAdapter({input, ctx})),
 })
 
 export type AccountingAdapter<TInstance> = AdapterFromRouter<

--- a/unified/unified-accounting/unifiedModels.ts
+++ b/unified/unified-accounting/unifiedModels.ts
@@ -120,6 +120,15 @@ export const customerIncome = z.object({
   netIncome: z.number(),
 });
 
-
-
-
+export const usBankAccount = z.object({
+  updated: z.string(),
+  name: z.string(),
+  accountNumber: z.string(),
+  default: z.boolean(),
+  created: z.string(),
+  inputType: z.string(),
+  phone: z.string(),
+  accountType: z.string(),
+  routingNumber: z.string(),
+  id: z.string(),
+});


### PR DESCRIPTION
This surfaces a unified API for getting bank accounts and payment receipts but without open SDKs directly for now as we'd need to migrate the schema 

The payment receipt API returns a PDF 

https://developer.intuit.com/app/developer/qbpayments/docs/api/resources/all-entities/paymentreceipt#get-a-payment-receipt